### PR TITLE
No ws condition in create cmd

### DIFF
--- a/dem/cli/command/create_cmd.py
+++ b/dem/cli/command/create_cmd.py
@@ -149,6 +149,10 @@ def create_new_dev_env(platform: DevEnvLocalSetup, new_dev_env_descriptor: dict)
     return new_dev_env
 
 def create_dev_env(platform: DevEnvLocalSetup, dev_env_name: str) -> DevEnv:
+    if ' ' in dev_env_name:
+        stderr.print("The name of the Development Environment cannot contain whitespace characters!")
+        raise typer.Abort()
+
     dev_env_original = platform.get_dev_env_by_name(dev_env_name)
     if dev_env_original is not None:
         typer.confirm("The input name is already used by a Development Environment. Overwrite it?", 

--- a/tests/cli/test_create_cmd.py
+++ b/tests/cli/test_create_cmd.py
@@ -224,3 +224,22 @@ def test_execute_failure(mock_DevEnvLocalSetup, mock_create_dev_env, mock_stderr
     mock_dev_env.check_image_availability.assert_called_once_with(mock_dev_env_local_setup.tool_images,
                                                                   update_tool_images=True)
     mock_stderr_print.assert_called_once_with("The installation failed.")
+
+@patch("dem.cli.command.create_cmd.stderr.print")
+def test_create_dev_env_with_whitespace(mock_stderr_print):
+    # Test setup
+    mock_dev_env_local_setup = MagicMock()
+    mock_dev_env_local_setup.get_dev_env_by_name.return_value = None
+
+    mock_tool_images = MagicMock()
+    mock_dev_env_local_setup.tool_images = mock_tool_images
+
+    expected_dev_env_name = "test dev env with space"
+
+    # Run unit under test
+    with pytest.raises(Exception):
+        create_cmd.create_dev_env(mock_dev_env_local_setup, expected_dev_env_name)
+
+    # Check expectations
+    mock_dev_env_local_setup.get_dev_env_by_name.assert_not_called()
+    mock_stderr_print.assert_called_once_with("The name of the Development Environment cannot contain whitespace characters!")


### PR DESCRIPTION
### Checklist:

* [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
* [x] I have checked to ensure there aren't other open Pull Requests for the same update/change
* [x] I have tested these changes and added tests that prove my fix is effective or that my feature works
* [ ] I have made corresponding changes to the documentation
* [x] New and existing unit tests pass locally with my changes
* [x] 100% unit test coverage achieved

(Documentation change doesn't seem necessary)

## Related Issue
Closing: #113 

## Type Of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Fixes whitespaces in Development Environment names. Adds validation in the create_dev_env() function in create_cmd.py. If a name with whitespace is provided, an error message is displayed, and the creation is aborted. Added test function in test_create_cmd.py to make sure that the function does not proceed to retrieve an existing Development Environment if the  name contains whitespace. It also tests if the error message is displayed.

## How Has This Been Tested?
Tested locally. Passed all unit tests in test_create_cmd.py before test_create_dev_env_with_whitespace() was added and passed all tests after. 

## Screenshots (if appropriate):
![image](https://github.com/axem-solutions/dem/assets/79218285/0a2cd5df-3662-457a-b790-ecb7cc80ca03)