### PR TITLE
New functionality for the delete command: deletes the Dev Env descriptor from the local storage.

### DIFF
--- a/dem/cli/command/delete_cmd.py
+++ b/dem/cli/command/delete_cmd.py
@@ -1,47 +1,24 @@
 """delete CLI command implementation."""
 # dem/cli/command/delete_cmd.py
 
-from dem.core.dev_env import DevEnv
 from dem.core.platform import Platform
+from dem.core.dev_env import DevEnv
 from dem.cli.console import stderr, stdout
 import typer
-import docker.errors
-
-def try_to_delete_tool_image(tool_image: str, dev_env_local_setup: Platform) -> None:
-    stdout.print("\nThe tool image [bold]" + tool_image + "[/bold] is not required by any Development Environment anymore.")
-    if typer.confirm("Would you like to remove it?"):
-        try:
-            dev_env_local_setup.container_engine.remove(tool_image)
-        except docker.errors.ImageNotFound:
-            stdout.print("[yellow]" + tool_image + " doesn't exist. Unable to remove it.[/]\n")
-        except docker.errors.APIError:
-            stderr.print("[red]Error: " + tool_image + " is used by a container. Unable to remove it.[/]\n")
-        else:
-            stdout.print("[green]Successfully removed![/]\n")
-
-def remove_unused_tool_images(deleted_dev_env: DevEnv, dev_env_local_setup: Platform) -> None:
-    all_required_tool_images = set()
-    for dev_env in dev_env_local_setup.local_dev_envs:
-        for tool in dev_env.tools:
-            all_required_tool_images.add(tool["image_name"] + ":" + tool["image_version"])
-
-    deleted_dev_env_tool_images = set()
-    for tool in deleted_dev_env.tools:
-        deleted_dev_env_tool_images.add(tool["image_name"] + ":" + tool["image_version"])
-
-    for tool_image in deleted_dev_env_tool_images:
-        if tool_image not in all_required_tool_images:
-            try_to_delete_tool_image(tool_image, dev_env_local_setup)
 
 def execute(platform: Platform, dev_env_name: str) -> None:
-    dev_env_to_delete = platform.get_dev_env_by_name(dev_env_name)
+    dev_env_to_delete: DevEnv | None = platform.get_dev_env_by_name(dev_env_name)
 
     if dev_env_to_delete is None:
-        stderr.print("[red]Error: The [bold]" + dev_env_name + "[/bold] Development Environment doesn't exist.")
+        stderr.print(f"[red]Error: The [bold]{dev_env_name}[/bold] Development Environment doesn't exist.")
     else:
+        if dev_env_to_delete.is_installed == "True":
+            typer.confirm("The Development Environment is installed. Do you want to uninstall it?", 
+                          abort=True)
+
+            platform.uninstall_dev_env(dev_env_to_delete)
+
         stdout.print("Deleting the Development Environment...")
         platform.local_dev_envs.remove(dev_env_to_delete)
         platform.flush_descriptors()
-
-        remove_unused_tool_images(dev_env_to_delete, platform)
-        stdout.print("[green]Successfully deleted the " + dev_env_name + "![/]")
+        stdout.print(f"[green]Successfully deleted the {dev_env_name}![/]")

--- a/dem/cli/main.py
+++ b/dem/cli/main.py
@@ -198,9 +198,8 @@ def modify(dev_env_name: Annotated[str, typer.Argument(help="Name of the Develop
 def delete(dev_env_name: Annotated[str, typer.Argument(help="Name of the Development Environment to delete.",
                                                        autocompletion=autocomplete_dev_env_name)]) -> None:
     """
-    Delete the Development Environment from the local setup. If a tool image is not required
-    anymore by any of the available local Development Environments, the DEM asks the user whether
-    they want to delete that image or not.
+    Delete the Dev Env descriptor from the local descriptor storage.
+    If the Dev Env is installed, the user will be asked whether they want to uninstall it. 
     """
     if platform:
         delete_cmd.execute(platform, dev_env_name)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -128,9 +128,8 @@ Arguments:
 
 ## **`dem delete DEV_ENV_NAME`**
 
-Delete the selected Development Environment. After the deletion, dem checks whether a tool image is
-required or not by any of the remaining local Development Environments. In case the tool image is
-not required anymore, the dem asks the user if they prefer to delete it or keep it.
+Delete the Dev Env descriptor from the local descriptor storage.
+If the Dev Env is installed, the user will be asked whether they want to uninstall it. 
 
 Arguments:
 


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
#122
[DEM-195](https://axem.atlassian.net/browse/DEM-195)

## Description
New functionality for the `delete` command: deletes the Dev Env descriptor from the local storage.

## How Has This Been Tested?
New test cases added.
Tested on Ubuntu 22.04.



[DEM-195]: https://axem.atlassian.net/browse/DEM-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ