### PR TITLE
A single tool in a Dev Env can be modified directly without opening the Dev Env settings panel.

### DIFF
--- a/dem/cli/main.py
+++ b/dem/cli/main.py
@@ -164,7 +164,7 @@ def load(path_to_dev_env: Annotated[str, typer.Argument(help="Path to the Dev En
         raise InternalError("Error: The platform hasn't been initialized properly!")
 
 @typer_cli.command()
-def clone(dev_env_name: Annotated[str, typer.Argument(help="Name of the Dev Env to clone.")]) -> None:
+def clone(dev_env_name: Annotated[str, typer.Argument(help="Name of the Dev Env descriptor to clone.")]) -> None:
     """
     Copy the Dev Env's descriptor from the catalog to the local descriptor storage.
     """
@@ -187,12 +187,15 @@ def rename(dev_env_name: Annotated[str, typer.Argument(help="Name of the Develop
 
 @typer_cli.command()
 def modify(dev_env_name: Annotated[str, typer.Argument(help="Name of the Development Environment to modify.",
-                                                       autocompletion=autocomplete_dev_env_name)]) -> None:
+                                                       autocompletion=autocomplete_dev_env_name)],
+           tool_type: Annotated[str, typer.Argument(help="The tool type to modify.")] = "",
+           tool_image: Annotated[str, typer.Argument(help="The tool image to set for the tool type.")] = "") -> None:
     """
-    Modify the tool types and required tool images for an existing Development Environment.
+    Modify a tool in a Development Environment.
+    If the tool type is not specified, the Dev Env settings panel will be opened.
     """
     if platform:
-        modify_cmd.execute(platform, dev_env_name)
+        modify_cmd.execute(platform, dev_env_name, tool_type, tool_image)
     else:
         raise InternalError("Error: The platform hasn't been initialized properly!")
 

--- a/dem/core/dev_env.py
+++ b/dem/core/dev_env.py
@@ -54,7 +54,7 @@ class DevEnv(Core):
 
         if descriptor:
             self.name: str = descriptor["name"]
-            self.tools: str = descriptor["tools"]
+            self.tools: list[dict[str, str]] = descriptor["tools"]
             descriptor_installed = descriptor.get("installed", "False")
             if "True" == descriptor_installed:
                 self.is_installed = True


### PR DESCRIPTION
## Type Of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
#112
[DEM-126](https://axem.atlassian.net/browse/DEM-126)

## Description
A single tool in a Dev Env can be modified directly without opening the Dev Env settings panel.

## How Has This Been Tested?
Tested on Ubuntu 22.04.


[DEM-126]: https://axem.atlassian.net/browse/DEM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ