### PR TITLE
Export command doesn't save the installation state anymore.

### DIFF
--- a/dem/cli/command/export_cmd.py
+++ b/dem/cli/command/export_cmd.py
@@ -2,54 +2,27 @@
 # dem/cli/command/export_cmd.py
 
 
-import re
+import os
 from dem.core.platform import Platform
+from dem.core.dev_env import DevEnv
 from dem.cli.console import stderr
-import json, os
 
-def check_is_directory(param: str):
-     if "" != param:
-        return(os.path.isdir(param))     
-     else:
-        return False
-     
-def check_is_path_contains_spec_char(param: str):
-    special_chars=re.compile('[~/\^]')
-    if "" != param:
-        if None != special_chars.search(param):
-            return True
-        else:
-            return False
-    else:
-        return False
+def export(dev_env: DevEnv, export_path: str):
+    if os.path.isdir(export_path):
+        export_path = f"{export_path}/{dev_env.name}"
+    elif "" == export_path:
+        export_path = dev_env.name
     
-def create_exported_dev_env_json(dev_env_name: str,dev_env_json: str,given_path: str):
-    
-    file_name=None
-    file_path=None
+    if not export_path.endswith(".json"):
+        export_path += ".json"
 
-    if True == check_is_directory(given_path):
-        file_name=dev_env_name
-        file_path=given_path+"/"
-    elif True == check_is_path_contains_spec_char(given_path):        
-        file_name=""
-        file_path=given_path         
-    elif "" != given_path:
-        file_name=given_path        
-        file_path=""    
-    else:
-        file_name=dev_env_name        
-        file_path=""
-    
-    exported_file = open(file_path+file_name, "w")        
-    json.dump(dev_env_json, exported_file, indent=4)
-    exported_file.close()        
+    dev_env.export(export_path)
 
-def execute(platform: Platform, dev_env_name: str, path_to_export: str) -> None:
-    dev_env_to_export = platform.get_dev_env_by_name(dev_env_name)
-    if dev_env_to_export is not None: 
+def execute(platform: Platform, dev_env_name: str, export_path: str) -> None:
+    dev_env = platform.get_dev_env_by_name(dev_env_name)
+    if dev_env:
         try:
-            create_exported_dev_env_json(dev_env_name,dev_env_to_export.__dict__,path_to_export)                
+            export(dev_env, export_path)
         except FileNotFoundError:
             stderr.print("[red]Error: Invalid input path.[/]")
     else:


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-234](https://axem.atlassian.net/browse/DEM-234)

## Description
Export command doesn't save the installation state anymore.

## How Has This Been Tested?
Tested on Ubuntu 22.04.


[DEM-234]: https://axem.atlassian.net/browse/DEM-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ