### PR TITLE
Missing uninstall call added to the clone command.

### DIFF
--- a/dem/cli/command/create_cmd.py
+++ b/dem/cli/command/create_cmd.py
@@ -44,7 +44,7 @@ def handle_tool_type_selector_panel(tool_type_selector_panel: ToolTypeSelectorPa
     tool_type_selector_panel.wait_for_user()
 
     if "cancel" in tool_type_selector_panel.cancel_next_menu.get_selection():
-        raise(typer.Abort())
+        raise typer.Abort()
 
     tool_type_selector_panel.cancel_next_menu.is_selected = False
 
@@ -176,7 +176,7 @@ def create_dev_env(platform: Platform, dev_env_name: str) -> None:
                 platform.uninstall_dev_env(dev_env_original)
             except PlatformError as e:
                 stderr.print(f"[red]{str(e)}[/]")
-                typer.Abort()
+                raise typer.Abort()
 
     tool_image_list = get_tool_image_list(platform.tool_images)
     new_dev_env_descriptor = get_dev_env_descriptor_from_user(dev_env_name, tool_image_list)

--- a/dem/cli/command/modify_cmd.py
+++ b/dem/cli/command/modify_cmd.py
@@ -45,7 +45,7 @@ def handle_tool_type_selector_panel(tool_type_selector_panel: ToolTypeSelectorPa
     tool_type_selector_panel.wait_for_user()
 
     if "cancel" in tool_type_selector_panel.cancel_next_menu.get_selection():
-        raise(typer.Abort())
+        raise typer.Abort()
 
     tool_type_selector_panel.cancel_next_menu.is_selected = False
 
@@ -151,7 +151,7 @@ def get_confirm_from_user() -> str:
 
 def handle_user_confirm(confirmation: str, dev_env_local: DevEnv, platform: Platform) -> None:
     if confirmation == "cancel":
-        raise(typer.Abort())
+        raise typer.Abort()
 
     if confirmation == "save as":
         new_dev_env = copy.deepcopy(dev_env_local)
@@ -163,7 +163,7 @@ def handle_user_confirm(confirmation: str, dev_env_local: DevEnv, platform: Plat
             platform.local_dev_envs.append(new_dev_env)
         else:
             stderr.print("[red]The Development Environment already exist.")
-            raise(typer.Abort())
+            raise typer.Abort()
 
     platform.flush_descriptors()
 

--- a/dem/cli/command/run_cmd.py
+++ b/dem/cli/command/run_cmd.py
@@ -37,7 +37,7 @@ def execute(platform: Platform, dev_env_name: str, container_arguments: list[str
 
     if dev_env_local is None:
         stderr.print("[red]Error: Unknown Development Environment: " + dev_env_name + "[/]")
-        raise(typer.Abort)
+        raise typer.Abort()
     else:
         # Update the tool images manually.
         Platform.update_tool_images_on_instantiation = False

--- a/dem/core/platform.py
+++ b/dem/core/platform.py
@@ -158,7 +158,7 @@ class Platform(Core):
                 try:                
                     self.container_engine.pull(f"{tool['image_name']}:{tool['image_version']}")
                 except ContainerEngineError as e:
-                    raise PlatformError(f"Dev Env install failed. Reason: {str(e)}")
+                    raise PlatformError(f"Dev Env install failed. --> {str(e)}")
 
         dev_env_to_install.is_installed = True
         self.flush_descriptors()
@@ -188,7 +188,7 @@ class Platform(Core):
             try:
                 self.container_engine.remove(tool_image)
             except ContainerEngineError as e:
-                raise PlatformError(f"Dev Env uninstall failed. <-caused by- {str(e)}")
+                raise PlatformError(f"Dev Env uninstall failed. --> {str(e)}")
             
         dev_env_to_uninstall.is_installed = False
         self.flush_descriptors()

--- a/tests/cli/test_create_cmd.py
+++ b/tests/cli/test_create_cmd.py
@@ -124,11 +124,10 @@ def test_create_dev_env_overwrite(mock_confirm, mock_get_tool_image_list,
     mock_get_dev_env_descriptor_from_user.assert_called_once_with(expected_dev_env_name,
                                                                   mock_tool_images)
 
-@patch("dem.cli.command.create_cmd.typer.Abort")
 @patch("dem.cli.command.create_cmd.stderr.print")
 @patch("dem.cli.command.create_cmd.typer.confirm")
-def test_create_dev_env_overwrite_PlatformError(mock_confirm: MagicMock, mock_stderr_print: MagicMock, 
-                                                mock_Abort: MagicMock) -> None:
+def test_create_dev_env_overwrite_PlatformError(mock_confirm: MagicMock, 
+                                                mock_stderr_print: MagicMock) -> None:
     # Test setup
     mock_platform = MagicMock()
     mock_dev_env_original = MagicMock()
@@ -136,12 +135,11 @@ def test_create_dev_env_overwrite_PlatformError(mock_confirm: MagicMock, mock_st
     mock_platform.get_dev_env_by_name.return_value = mock_dev_env_original
     test_exception_text = "test_exception_text"
     mock_platform.uninstall_dev_env.side_effect = create_cmd.PlatformError(test_exception_text)
-    mock_Abort.side_effect = Exception("")
 
     test_dev_env_name = "test_dev_env"
 
     # Run unit under test
-    with pytest.raises(Exception):
+    with pytest.raises(create_cmd.typer.Abort):
         create_cmd.create_dev_env(mock_platform, test_dev_env_name)
 
     # Check expectations
@@ -154,7 +152,6 @@ def test_create_dev_env_overwrite_PlatformError(mock_confirm: MagicMock, mock_st
     ])
     mock_platform.uninstall_dev_env.assert_called_once_with(mock_dev_env_original)
     mock_stderr_print.assert_called_once_with(f"[red]Platform error: {test_exception_text}[/]")
-    mock_Abort.assert_called_once()
 
 @patch("dem.cli.command.create_cmd.get_dev_env_descriptor_from_user")
 @patch("dem.cli.command.create_cmd.typer.confirm")
@@ -228,7 +225,7 @@ def test_create_dev_env_with_whitespace(mock_stderr_print):
     expected_dev_env_name = "test dev env with space"
 
     # Run unit under test
-    with pytest.raises(Exception):
+    with pytest.raises(create_cmd.typer.Abort):
         create_cmd.create_dev_env(mock_dev_env_local_setup, expected_dev_env_name)
 
     # Check expectations

--- a/tests/core/test_platform.py
+++ b/tests/core/test_platform.py
@@ -351,8 +351,8 @@ def test_Platform_install_dev_env_pull_failure(mock___init__: MagicMock, mock_us
         test_platform.install_dev_env(mock_dev_env)
 
     # Check expectations
-    assert str(exported_exception_info.value) == f"Platform error: Dev Env install failed. Reason:" + \
-                                                 f" Container engine error: {test_exception_text}"
+    assert str(exported_exception_info.value) == "Platform error: Dev Env install failed. --> " + \
+                                                 f"Container engine error: {test_exception_text}"
 
     mock___init__.assert_called_once()
 
@@ -580,7 +580,7 @@ def test_Platform_uninstall_dev_env_failure(mock___init__: MagicMock,
         # Check expectations
         mock___init__.assert_called_once()
 
-        assert str(exported_exception_info) == "Platform error: Dev Env uninstall failed. <-caused by-"
+        assert str(exported_exception_info) == "Platform error: Dev Env uninstall failed. --> "
         assert mock_dev_env_to_uninstall.is_installed == True
 
         mock_container_engine.remove.asssert_called_once_with("test_image_name4:test_image_version4")

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -560,7 +560,7 @@ def test_Registries_list_repos_handle_exception(mock___init__: MagicMock,
 
         @property
         def repos(self) -> list[str]:
-            raise(Exception(test_exception_text))
+            raise Exception(test_exception_text)
 
     test_registries = registry.Registries(MagicMock())
     test_registries.registries = [StubRegistry()]


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-230](https://axem.atlassian.net/browse/DEM-230)

## Description
Uninstall call added when the clone command tries to overwrite an installed local Dev Env. 
Exception raises unified for the `raise Exception()` format.

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-230]: https://axem.atlassian.net/browse/DEM-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ