### PR TITLE
Autocompletion error fixed.

### DIFF
--- a/dem/__main__.py
+++ b/dem/__main__.py
@@ -25,6 +25,9 @@ def main() -> None:
         # Load the configuration file
         dem.cli.main.platform.config_file.update()
 
+        # Load the Dev Env descriptors
+        dem.cli.main.platform.load_dev_envs()
+
         # Run the CLI application
         dem.cli.main.typer_cli(prog_name=__command__)
     except LookupError as e:
@@ -40,8 +43,8 @@ def main() -> None:
             stdout.print("\nHint: The input repository might not exist in the registry.")
         elif "400" in str(e):
             stdout.print("\nHint: The input parameters might not be valid.")
-    except (ContainerEngineError, InternalError, ToolImageError) as e:
-        stderr.print("[red]" + str(e) + "[/]")
+    except (ContainerEngineError, InternalError, ToolImageError, CatalogError) as e:
+        stderr.print(f"[red]{str(e)}[/]")
     except DataStorageError as e:
         stderr.print("[red]" + str(e) + "[/]")
         if typer.confirm("Do you want to reset the file?"):
@@ -51,8 +54,6 @@ def main() -> None:
             elif "dev_env.json" in str(e):
                 stdout.print("Restoring the original Dev Env descriptor file...")
                 dem.cli.main.platform.dev_env_json.restore()
-    except CatalogError as e:
-        stderr.print(f"[red]{str(e)}[/]")
 
 # Call the main() when run as `python -m`
 if __name__ == "__main__":

--- a/dem/cli/command/assign_cmd.py
+++ b/dem/cli/command/assign_cmd.py
@@ -14,8 +14,7 @@ def execute(platform: Platform, dev_env_name: str, project_path: str) -> None:
             dev_env_name -- the name of the Development Environment to assign
             project_path -- the path to the project to assign the Development Environment to
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     if not os.path.isdir(project_path):
         stderr.print(f"[red]Error: The {project_path} path does not exist.[/]")

--- a/dem/cli/command/clone_cmd.py
+++ b/dem/cli/command/clone_cmd.py
@@ -37,8 +37,7 @@ def execute(platform: Platform, dev_env_name: str) -> None:
             platform -- the platform
             dev_env_name -- name of the Dev Env to clone
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     catalog_dev_env: DevEnv | None = None
 

--- a/dem/cli/command/cp_cmd.py
+++ b/dem/cli/command/cp_cmd.py
@@ -31,8 +31,7 @@ def cp_given_dev_env(platform: Platform, dev_env_to_cp: DevEnv,
     platform.flush_descriptors()
 
 def execute(platform: Platform, dev_env_to_cp_name: str, new_dev_env_name: str) -> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     dev_env_to_cp = get_dev_env_to_cp(platform, dev_env_to_cp_name)
 

--- a/dem/cli/command/create_cmd.py
+++ b/dem/cli/command/create_cmd.py
@@ -115,8 +115,6 @@ def execute(platform: Platform, dev_env_name: str) -> None:
         Exceptions:
             Abort -- if the name of the Development Environment contains whitespace characters
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
     platform.assign_tool_image_instances_to_all_dev_envs()
 
     create_dev_env(platform, dev_env_name)

--- a/dem/cli/command/delete_cmd.py
+++ b/dem/cli/command/delete_cmd.py
@@ -8,8 +8,7 @@ from dem.cli.console import stderr, stdout
 import typer
 
 def execute(platform: Platform, dev_env_name: str) -> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     dev_env_to_delete: DevEnv | None = platform.get_dev_env_by_name(dev_env_name)
 

--- a/dem/cli/command/export_cmd.py
+++ b/dem/cli/command/export_cmd.py
@@ -19,8 +19,7 @@ def export(dev_env: DevEnv, export_path: str):
     dev_env.export(export_path)
 
 def execute(platform: Platform, dev_env_name: str, export_path: str) -> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     dev_env = platform.get_dev_env_by_name(dev_env_name)
     if dev_env:

--- a/dem/cli/command/info_cmd.py
+++ b/dem/cli/command/info_cmd.py
@@ -15,6 +15,11 @@ image_status_messages = {
 }
 
 def print_info(dev_env: DevEnv) -> None:
+    """ Print information about the given Development Environment.
+    
+        Args:
+            dev_env -- the Development Environment to print information about
+    """
     tool_info_table = Table()
     tool_info_table.add_column("Image")
     tool_info_table.add_column("Status")
@@ -25,8 +30,12 @@ def print_info(dev_env: DevEnv) -> None:
     stdout.print(tool_info_table)
 
 def execute(platform: Platform, arg_dev_env_name: str) -> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+    """ Print information about the given Development Environment.
+    
+        Args:
+            platform -- the platform
+            arg_dev_env_name -- the name of the Development Environment to print information about
+    """
     platform.assign_tool_image_instances_to_all_dev_envs()
 
     dev_env = platform.get_dev_env_by_name(arg_dev_env_name)

--- a/dem/cli/command/init_cmd.py
+++ b/dem/cli/command/init_cmd.py
@@ -14,8 +14,7 @@ def execute(platform: Platform, project_path: str) -> None:
             platform -- the platform
             project_path -- the path to the project to initialize
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     if not os.path.isdir(project_path):
         stderr.print(f"[red]Error: The {project_path} path does not exist.[/]")

--- a/dem/cli/command/install_cmd.py
+++ b/dem/cli/command/install_cmd.py
@@ -13,8 +13,7 @@ def execute(platform: Platform, dev_env_name: str) -> None:
             platform -- the platform
             dev_env_name -- the name of the Development Environment to install
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
     platform.assign_tool_image_instances_to_all_dev_envs()
 
     dev_env_to_install: DevEnv | None = platform.get_dev_env_by_name(dev_env_name)

--- a/dem/cli/command/list_cmd.py
+++ b/dem/cli/command/list_cmd.py
@@ -64,8 +64,7 @@ def get_local_dev_env_status(dev_env: DevEnv, tool_images: ToolImage) -> str:
     return dev_env_status
 
 def list_dev_envs(platform: Platform, local: bool, org: bool)-> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     table = Table()
     table.add_column("Development Environment")

--- a/dem/cli/command/load_cmd.py
+++ b/dem/cli/command/load_cmd.py
@@ -32,8 +32,7 @@ def load_dev_env_to_dev_env_json(platform: Platform,path_to_dev_env: str) -> boo
         return True
 
 def execute(platform: Platform, path_to_dev_env: str) -> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     if check_is_file_exist(path_to_dev_env) is True:                
         retval = load_dev_env_to_dev_env_json(platform,path_to_dev_env)        

--- a/dem/cli/command/modify_cmd.py
+++ b/dem/cli/command/modify_cmd.py
@@ -165,8 +165,7 @@ def execute(platform: Platform, dev_env_name: str) -> None:
         Exceptions:
             typer.Abort -- if the user cancels the operation
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
     platform.assign_tool_image_instances_to_all_dev_envs()
 
     dev_env = platform.get_dev_env_by_name(dev_env_name)

--- a/dem/cli/command/rename_cmd.py
+++ b/dem/cli/command/rename_cmd.py
@@ -5,8 +5,7 @@ from dem.core.platform import Platform
 from dem.cli.console import stderr
 
 def execute(platform: Platform, dev_env_name_to_rename: str, new_dev_env_name: str) -> None:
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     dev_env_to_rename = platform.get_dev_env_by_name(dev_env_name_to_rename)
 

--- a/dem/cli/command/run_cmd.py
+++ b/dem/cli/command/run_cmd.py
@@ -32,8 +32,7 @@ def execute(platform: Platform, dev_env_name: str, container_arguments: list[str
             dev_env_name -- name of the Development Environment
             container_arguments -- arguments passed to the container
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     dev_env_local = platform.get_dev_env_by_name(dev_env_name)
 

--- a/dem/cli/command/uninstall_cmd.py
+++ b/dem/cli/command/uninstall_cmd.py
@@ -13,8 +13,7 @@ def execute(platform: Platform, dev_env_name: str) -> None:
             platform -- the platform
             dev_env_name -- the name of the Development Environment to uninstall
     """
-    # Load the Dev Envs
-    platform.load_dev_envs()
+
 
     dev_env_to_uninstall: DevEnv | None = platform.get_dev_env_by_name(dev_env_name)
 

--- a/tests/cli/test_info_cmd.py
+++ b/tests/cli/test_info_cmd.py
@@ -87,7 +87,6 @@ def test_execute_dev_env_not_found(mock_stderr_print: MagicMock) -> None:
     # Check expectations
     assert runner_result.exit_code == 0
     
-    mock_platform.load_dev_envs.assert_called_once()
     mock_platform.assign_tool_image_instances_to_all_dev_envs.assert_called_once()
     mock_platform.get_dev_env_by_name.assert_called_once_with(test_dev_env_name)
     mock_stderr_print.assert_called_once_with(f"[red]Error: Unknown Development Environment: {test_dev_env_name}[/]\n")
@@ -113,7 +112,6 @@ def test_execute(mock_print_info: MagicMock) -> None:
     # Check expectations
     assert runner_result.exit_code == 0
 
-    mock_platform.load_dev_envs.assert_called_once()
     mock_platform.assign_tool_image_instances_to_all_dev_envs.assert_called_once()
     mock_platform.get_dev_env_by_name.assert_called_once_with(test_dev_env_name)
     mock_catalog.request_dev_envs.assert_called_once()


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-257](https://axem.atlassian.net/browse/DEM-257)

## Description
The Dev Env descriptors can be loaded before the CLI starts, only the Tool Image 
assigment must be postponed until the point where actually needed.
The autocompletion for the Dev Env names were failing because, the Dev Env 
descriptors were only loaded at the beginning of the CLI commands. Now the Dev
Env loading moved to the `main()` function so the required information will be 
available for the `autocomplete_dev_env_name()`.
<!--- Describe your changes in detail. List any dependencies that are required for this change.-->

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-257]: https://axem.atlassian.net/browse/DEM-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ