### PR TITLE
Unhandled exception fixed when not existing Dev Env name is supplied for the info command.

### DIFF
--- a/dem/cli/command/info_cmd.py
+++ b/dem/cli/command/info_cmd.py
@@ -44,7 +44,8 @@ def execute(platform: Platform, arg_dev_env_name: str) -> None:
         for catalog in platform.dev_env_catalogs.catalogs:
             catalog.request_dev_envs()
             dev_env = catalog.get_dev_env_by_name(arg_dev_env_name)
-            dev_env.assign_tool_image_instances(platform.tool_images)
+            if dev_env:
+                dev_env.assign_tool_image_instances(platform.tool_images)
             break
 
     if dev_env is None:


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-258](https://axem.atlassian.net/browse/DEM-258)

## Description
Only try to assign the tool images if the Dev Env is available from a catalog.

## How Has This Been Tested?
Tested on Ubuntu 22.04.


[DEM-258]: https://axem.atlassian.net/browse/DEM-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ