### PR TITLE
DEM now presents a warning if the user tries to uninstall an installed Dev Env that requires an unavailable tool image..

### DIFF
--- a/dem/cli/command/clone_cmd.py
+++ b/dem/cli/command/clone_cmd.py
@@ -21,7 +21,8 @@ def handle_existing_local_dev_env(platform: Platform, local_dev_env: DevEnv) -> 
         typer.confirm("The Dev Env to overwrite is installed. Do you want to uninstall it?", 
                       abort=True)
         try:
-            platform.uninstall_dev_env(local_dev_env)
+            for status in platform.uninstall_dev_env(local_dev_env):
+                stdout.print(status)
         except PlatformError as e:
             stderr.print(f"[red]{str(e)}[/]")
             raise typer.Abort()

--- a/dem/cli/command/create_cmd.py
+++ b/dem/cli/command/create_cmd.py
@@ -92,7 +92,8 @@ def create_dev_env(platform: Platform, dev_env_name: str) -> None:
             typer.confirm("The Development Environment is installed, so it can't be overwritten. " + \
                           "Uninstall it first?", abort=True)
             try:
-                platform.uninstall_dev_env(dev_env_original)
+                for status in platform.uninstall_dev_env(dev_env_original):
+                    stdout.print(status)
             except PlatformError as e:
                 stderr.print(f"[red]{str(e)}[/]")
                 raise typer.Abort()

--- a/dem/cli/command/delete_cmd.py
+++ b/dem/cli/command/delete_cmd.py
@@ -20,12 +20,13 @@ def execute(platform: Platform, dev_env_name: str) -> None:
                           abort=True)
 
             try:
-                platform.uninstall_dev_env(dev_env_to_delete)
+                for status in platform.uninstall_dev_env(dev_env_to_delete):
+                    stdout.print(status)
             except PlatformError as e:
                 stderr.print(f"[red]{str(e)}[/]")
                 return
 
-        stdout.print("Deleting the Development Environment...")
+        stdout.print("Deleting the Development Environment descriptor...")
         platform.local_dev_envs.remove(dev_env_to_delete)
         platform.flush_dev_env_properties()
         stdout.print(f"[green]Successfully deleted the {dev_env_name}![/]")

--- a/dem/cli/command/init_cmd.py
+++ b/dem/cli/command/init_cmd.py
@@ -34,7 +34,8 @@ def execute(platform: Platform, project_path: str) -> None:
                               abort=True)
                 
                 try:
-                    platform.uninstall_dev_env(local_dev_env)
+                    for status in platform.uninstall_dev_env(local_dev_env):
+                        stdout.print(status)
                 except PlatformError as e:
                     stderr.print(f"[red]{str(e)}[/]")
                     return

--- a/dem/cli/command/modify_cmd.py
+++ b/dem/cli/command/modify_cmd.py
@@ -177,7 +177,8 @@ def execute(platform: Platform, dev_env_name: str) -> None:
         stdout.print("[yellow]The Development Environment is installed, so it can't be modified.[/]")
         typer.confirm("Do you want to uninstall it first?", abort=True)
         try:
-            platform.uninstall_dev_env(dev_env)
+            for status in platform.uninstall_dev_env(dev_env):
+                stdout.print(status)
         except PlatformError as e:
             stderr.print(f"[red]{str(e)}[/]")
             return

--- a/dem/cli/command/uninstall_cmd.py
+++ b/dem/cli/command/uninstall_cmd.py
@@ -23,7 +23,8 @@ def execute(platform: Platform, dev_env_name: str) -> None:
         stderr.print(f"[red]Error: The {dev_env_name} Development Environment is not installed.[/]")
     else:
         try:
-            platform.uninstall_dev_env(dev_env_to_uninstall)
+            for status in platform.uninstall_dev_env(dev_env_to_uninstall):
+                stdout.print(status)
         except PlatformError as e:
             stderr.print(f"[red]{str(e)}[/]")
         else:

--- a/dem/core/container_engine.py
+++ b/dem/core/container_engine.py
@@ -104,10 +104,11 @@ class ContainerEngine(Core):
     def remove(self, image: str) -> None:
         """ Remove a tool image.
 
-            If the removal was successful return with True, otherwise return with False.
-        
             Args: 
                 image -- the tool image to remove
+
+            Raises:
+                ContainerEngineError -- if the image is used by a container
         """
         try:
             self._docker_client.images.remove(image)
@@ -115,8 +116,6 @@ class ContainerEngine(Core):
             self.user_output.msg(f"[yellow]The {image} doesn't exist. Unable to remove it.[/]\n")
         except docker.errors.APIError:
             raise ContainerEngineError(f"The {image} is used by a container. Unable to remove it.\n")
-        else:
-            self.user_output.msg(f"[green]Successfully removed the {image}![/]\n")
 
     def search(self, registry: str) -> list[str]:
         """ Search repository in the axemsolutions registry.

--- a/tests/cli/test_clone_cmd.py
+++ b/tests/cli/test_clone_cmd.py
@@ -20,11 +20,17 @@ def test_handle_existing_local_dev_env(mock_stdout_print: MagicMock, mock_typer_
     mock_platform = MagicMock()
     mock_local_dev_env = MagicMock()
 
+    test_uninstall_dev_env_status = ["test_uninstall_dev_env_status", 
+                                     "test_uninstall_dev_env_status2"]
+    mock_platform.uninstall_dev_env.return_value = test_uninstall_dev_env_status
+
     # Run unit under test
     clone_cmd.handle_existing_local_dev_env(mock_platform, mock_local_dev_env)
 
     # Check expectations
-    mock_stdout_print.assert_called_once_with("[yellow]The Dev Env already exists.[/]")
+    mock_stdout_print.assert_has_calls([call("[yellow]The Dev Env already exists.[/]"),
+                                        call(test_uninstall_dev_env_status[0]),
+                                        call(test_uninstall_dev_env_status[1])])
     mock_typer_confirm.assert_has_calls([call("Continue with overwrite?", abort=True),
                                          call("The Dev Env to overwrite is installed. Do you want to uninstall it?", 
                                               abort=True)])

--- a/tests/cli/test_create_cmd.py
+++ b/tests/cli/test_create_cmd.py
@@ -145,8 +145,9 @@ def test_create_dev_env_new(mock_open_dev_env_settings_panel: MagicMock,
 
 @patch("dem.cli.command.create_cmd.create_new_dev_env_descriptor")
 @patch("dem.cli.command.create_cmd.open_dev_env_settings_panel")
+@patch("dem.cli.command.create_cmd.stdout.print")
 @patch("dem.cli.command.create_cmd.typer.confirm")
-def test_create_dev_env_overwrite_installed(mock_confirm: MagicMock, 
+def test_create_dev_env_overwrite_installed(mock_confirm: MagicMock, mock_stdout_print: MagicMock,
                                             mock_open_dev_env_settings_panel: MagicMock, 
                                             mock_create_new_dev_env_descriptor: MagicMock) -> None:
     # Test setup
@@ -162,6 +163,9 @@ def test_create_dev_env_overwrite_installed(mock_confirm: MagicMock,
 
     mock_selected_tool_images = MagicMock()
     mock_open_dev_env_settings_panel.return_value = mock_selected_tool_images
+
+    test_uninstall_dev_env_status = ["status1", "status2"]
+    mock_platform.uninstall_dev_env.return_value = test_uninstall_dev_env_status
 
     test_dev_env_name = "test_dev_env"
 
@@ -179,6 +183,10 @@ def test_create_dev_env_overwrite_installed(mock_confirm: MagicMock,
              "Uninstall it first?", abort=True)
     ])
     mock_platform.uninstall_dev_env.assert_called_once_with(mock_dev_env_original)
+    mock_stdout_print.assert_has_calls([
+        call("status1"),
+        call("status2")
+    ])
     mock_open_dev_env_settings_panel.assert_called_once_with(mock_platform.tool_images.all_tool_images)
     mock_create_new_dev_env_descriptor.assert_called_once_with(test_dev_env_name, 
                                                                mock_selected_tool_images)

--- a/tests/cli/test_delete_cmd.py
+++ b/tests/cli/test_delete_cmd.py
@@ -25,6 +25,10 @@ def test_delete(mock_stdout_print: MagicMock, mock_config: MagicMock) -> None:
     mock_platform.get_dev_env_by_name.return_value = test_dev_env
     mock_platform.local_dev_envs = [test_dev_env]
 
+    test_uninstall_dev_env_status = ["test_uninstall_dev_env_status",
+                                     "test_uninstall_dev_env_status2"]
+    mock_platform.uninstall_dev_env.return_value = test_uninstall_dev_env_status
+
     # Run unit under test
     runner_result = runner.invoke(main.typer_cli, ["delete", test_dev_env_name])
 
@@ -37,7 +41,8 @@ def test_delete(mock_stdout_print: MagicMock, mock_config: MagicMock) -> None:
                                         abort=True)
     mock_platform.uninstall_dev_env.assert_called_once_with(test_dev_env)
     mock_stdout_print.assert_has_calls([
-        call("Deleting the Development Environment..."),
+        call(test_uninstall_dev_env_status[0]), call(test_uninstall_dev_env_status[1]),
+        call("Deleting the Development Environment descriptor..."),
         call(f"[green]Successfully deleted the {test_dev_env_name}![/]")
     ])
     mock_platform.flush_dev_env_properties.assert_called_once()

--- a/tests/cli/test_init_cmd.py
+++ b/tests/cli/test_init_cmd.py
@@ -87,6 +87,10 @@ def test_execute_reinit_installed(mock_DevEnv, mock_confirm, mock_stdout_print, 
     mock_local_dev_env.is_installed = True
     mock_platform.local_dev_envs = [mock_local_dev_env]
 
+    test_uninstall_dev_env_status = ["test_uninstall_dev_env_status",
+                                     "test_uninstall_dev_env_status2"]
+    mock_platform.uninstall_dev_env.return_value = test_uninstall_dev_env_status
+
     # Run unit under test
     init_cmd.execute(mock_platform, mock_project_path)
 
@@ -100,8 +104,10 @@ def test_execute_reinit_installed(mock_DevEnv, mock_confirm, mock_stdout_print, 
                                    call("The Development Environment is installed, so it can't be deleted. Do you want to uninstall it first?", abort=True)])
     mock_platform.uninstall_dev_env.assert_called_once_with(mock_local_dev_env)
     mock_platform.flush_dev_env_properties.assert_called_once()
-    mock_stdout_print.assert_has_calls([call(f"[green]Successfully initialized the {mock_dev_env_name} Dev Env for the project at {mock_project_path}![/]"),
-                                        call(f"\nNow you can install the Dev Env with the `dem install {mock_dev_env_name}` command.")])
+    mock_stdout_print.assert_has_calls([
+        call(test_uninstall_dev_env_status[0]), call(test_uninstall_dev_env_status[1]),
+        call(f"[green]Successfully initialized the {mock_dev_env_name} Dev Env for the project at {mock_project_path}![/]"),
+        call(f"\nNow you can install the Dev Env with the `dem install {mock_dev_env_name}` command.")])
 
 @patch("dem.cli.command.init_cmd.os.path.isdir")
 @patch("dem.cli.command.init_cmd.stderr.print")

--- a/tests/cli/test_uninstall_cmd.py
+++ b/tests/cli/test_uninstall_cmd.py
@@ -6,7 +6,7 @@ import dem.cli.command.uninstall_cmd as uninstall_cmd
 
 # Test framework
 from typer.testing import CliRunner
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 ## Global test variables
 runner = CliRunner()
@@ -30,7 +30,7 @@ def test_uninstall_dev_env_invalid_name(mock_stderr_print):
     mock_stderr_print.assert_called_once_with(f"[red]Error: The {test_invalid_name} Development Environment does not exist.[/]")
 
 @patch("dem.cli.command.uninstall_cmd.stdout.print")
-def test_uninstall_dev_env_valid_name(mock_stdout_print):
+def test_uninstall_dev_env_valid_name(mock_stdout_print: MagicMock) -> None:
      # Test setup
     fake_dev_env_to_uninstall = MagicMock()
     fake_dev_env_to_uninstall.name = "dev_env"
@@ -39,15 +39,24 @@ def test_uninstall_dev_env_valid_name(mock_stdout_print):
     mock_platform.get_dev_env_by_name.return_value = fake_dev_env_to_uninstall
     main.platform = mock_platform
 
+    test_uninstall_dev_env_status = ["test_uninstall_dev_env_status", 
+                                     "test_uninstall_dev_env_status2"]
+    mock_platform.uninstall_dev_env.return_value = test_uninstall_dev_env_status
+
     # Run unit under test
-    runner_result = runner.invoke(main.typer_cli, ["uninstall", fake_dev_env_to_uninstall.name ], color=True)
+    runner_result = runner.invoke(main.typer_cli, ["uninstall", fake_dev_env_to_uninstall.name], 
+                                  color=True)
 
     # Check expectations
     assert 0 == runner_result.exit_code
     
     mock_platform.get_dev_env_by_name.assert_called_once_with(fake_dev_env_to_uninstall.name )
     mock_platform.uninstall_dev_env.assert_called_once_with(fake_dev_env_to_uninstall)
-    mock_stdout_print.assert_called_once_with(f"[green]Successfully uninstalled the {fake_dev_env_to_uninstall.name}![/]")
+    mock_stdout_print.assert_has_calls([
+        call(test_uninstall_dev_env_status[0]),
+        call(test_uninstall_dev_env_status[1]), 
+        call(f"[green]Successfully uninstalled the {fake_dev_env_to_uninstall.name}![/]")
+    ])
 
 @patch("dem.cli.command.uninstall_cmd.stderr.print")
 def test_uninstall_dev_env_valid_name_not_installed(mock_stderr_print):

--- a/tests/core/test_container_engine.py
+++ b/tests/core/test_container_engine.py
@@ -254,7 +254,6 @@ def test_remove(mock_from_env: MagicMock, mock_user_output: MagicMock) -> None:
 
     # Check expectations
     mock_docker_client.images.remove.assert_called_once_with(test_image_to_remove)
-    mock_user_output.msg.assert_called_once_with(f"[green]Successfully removed the {test_image_to_remove}![/]\n")
 
 @patch.object(container_engine.ContainerEngine, "user_output")
 @patch("docker.from_env")


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-276](https://axem.atlassian.net/browse/DEM-276)

## Description
When the user wanted to uninstall an installed Dev Env that required at least 
one tool image, which not existed anymore, DEM preseneted a wrong error message
indicating that the missing image is used by a container. 
Instead, now DEM shows a warning that the image is not available anymore so 
can't be removed and the uninstallation process finishes anyway.

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-276]: https://axem.atlassian.net/browse/DEM-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ