### PR TITLE
Output of the list command improved: the first column aligned to the left, the others aligned to the middle.

### DIFF
--- a/dem/cli/command/list_cmd.py
+++ b/dem/cli/command/list_cmd.py
@@ -47,9 +47,9 @@ def list_local_dev_envs(platform: Platform) -> None:
     else:
         table = Table()
         table.add_column("Name")
-        table.add_column("Installed")
-        table.add_column("Default")
-        table.add_column("Status")
+        table.add_column("Installed", justify="center")
+        table.add_column("Default", justify="center")
+        table.add_column("Status", justify="center")
 
         for dev_env in sorted(platform.local_dev_envs, key=lambda dev_env: dev_env.name.lower()):
             add_dev_env_info_to_table(platform, table, dev_env)

--- a/tests/cli/test_list_cmd.py
+++ b/tests/cli/test_list_cmd.py
@@ -121,8 +121,10 @@ def test_list_local_dev_envs(mock_add_dev_env_info_to_table: MagicMock, mock_Tab
     list_cmd.list_local_dev_envs(mock_platform)
 
     # Check the result
-    mock_table.add_column.assert_has_calls([call("Name"), call("Installed"), call("Default"),
-                                            call("Status")])
+    mock_table.add_column.assert_has_calls([call("Name"), 
+                                            call("Installed", justify="center"), 
+                                            call("Default", justify="center"), 
+                                            call("Status", justify="center")])
     mock_add_dev_env_info_to_table.assert_called_once_with(mock_platform, mock_table, mock_dev_env)
     mock_stdout_print.assert_has_calls([call(f"\n [italic]Local Development Environments[/]"), 
                                         call(mock_table)])


### PR DESCRIPTION
## Type Of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-277](https://axem.atlassian.net/browse/DEM-277)

## Description
The output table of the `list` command aligned:
- The first column to the left
- All the other columns to the middle

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-277]: https://axem.atlassian.net/browse/DEM-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ