### PR TITLE
The run command doc updated. Links to the run and set-default commands fixed.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -384,7 +384,7 @@ Rename the Development Environment.
 
 ---
 
-## **`dem run DEV_ENV_NAME *`**
+## **`dem run [DEV_ENV_NAME] TASK_NAME`**
 
 **Description:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,8 @@ nav:
       - 'list-tools': 'commands/#dem-list-tools-options-registry_names'
       - 'modify': 'commands/#dem-modify-dev_env_name'
       - 'rename': 'commands/#dem-rename-dev_env_name-new_dev_env_name'
-      - 'run': 'commands/#dem-run-dev_env_name-*'
+      - 'run': 'commands/#dem-run-dev_env_name-task_name'
+      - 'set-default': 'commands/#dem-set-default-dev_env_name'
       - 'uninstall': 'commands/#dem-uninstall-dev_env_name'
     - 'Catalog Management':
       - 'add-cat': 'commands/#dem-add-cat-name-url'


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-280](https://axem.atlassian.net/browse/DEM-280)

## Description
- The `run` command doc updated. 
- Links to the `run` and `set-default` commands fixed in the navigation bar.

## How Has This Been Tested?
The DEM doc website has been generated on Ubuntu 22.04.


[DEM-280]: https://axem.atlassian.net/browse/DEM-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ