### PR TITLE
Fixed the issue when DEM couldn't find the existing repositories.

### DIFF
--- a/dem/core/registry.py
+++ b/dem/core/registry.py
@@ -148,7 +148,7 @@ class DockerHub(Registry):
                 repo -- append the tags of this repoistory
         """
         for result in endpoint_response[self._tag_endpoint_response_key]:
-            self._repos.append(repo + ":" + result["name"])
+            self._repos.append(self._namespace + "/" + repo + ":" + result["name"])
 
     def _get_repo_endpoint_url(self) -> str:
         """ Get the Docker Hub specific endpoint url to obtain the repositories.
@@ -186,7 +186,7 @@ class DockerRegistry(Registry):
                 repo -- append the tags of this repoistory
         """
         for result in endpoint_response[self._tag_endpoint_response_key]:
-            self._repos.append(repo + ":" + result)
+            self._repos.append(self._url + "/" + repo + ":" + result)
 
     def _get_repo_endpoint_url(self) -> str:
         """ Get the Docker Registry specific endpoint url to obtain the repositories.

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -387,9 +387,11 @@ def test_DockerHub__append_repo_with_tag(mock___init__: MagicMock) -> None:
         ]
     }
     test_repo = "test_repo"
+    test_namespace = "test_namespace"
 
     test_docker_hub = registry.DockerHub(test_registry_config)
     test_docker_hub._repos = []
+    test_docker_hub._namespace = test_namespace
 
     # Run unit under test
     test_docker_hub._append_repo_with_tag(test_endpoint_response, test_repo)
@@ -397,7 +399,7 @@ def test_DockerHub__append_repo_with_tag(mock___init__: MagicMock) -> None:
     # Check expectations
     expected_repos = []
     for test_result in test_endpoint_response["results"]:
-        expected_repos.append(test_repo + ":" + test_result["name"])
+        expected_repos.append(test_namespace + "/" + test_repo + ":" + test_result["name"])
     assert expected_repos == test_docker_hub._repos
 
     mock___init__.assert_called_once()
@@ -450,15 +452,17 @@ def test_DockerRegistry__append_repo_with_tag(mock___init__: MagicMock) -> None:
         "tags": ["latest", "v0.0.1"]
     }
     test_repo = "test_repo"
+    test_registry_url = "test_registry_url"
 
     test_docker_registry = registry.DockerRegistry(test_registry_config)
     test_docker_registry._repos = []
+    test_docker_registry._url = test_registry_url
 
     # Run unit under test
     test_docker_registry._append_repo_with_tag(test_endpoint_response, test_repo)
 
     # Check expectations
-    expected_repos = [test_repo + ":" + test_result for test_result in test_endpoint_response["tags"]]
+    expected_repos = [test_registry_url + "/" + test_repo + ":" + test_result for test_result in test_endpoint_response["tags"]]
     assert expected_repos == test_docker_registry._repos
 
     mock___init__.assert_called_once()


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-289](https://axem.atlassian.net/browse/DEM-289)

## Description
DEM couldn't find the images available from the registries, because it loaded 
the repo information without the namespece (DockerHub) and URL (other registries)
information. The fix was to prepend these information when updating the Registry 
classes.

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-289]: https://axem.atlassian.net/browse/DEM-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ