### PR TITLE
Default registry config updated.

### DIFF
--- a/dem/core/data_management.py
+++ b/dem/core/data_management.py
@@ -92,7 +92,8 @@ class ConfigFile(BaseJSON):
         self._default_json = """{
     "registries": [
         {
-            "name": "axemsolutions",
+            "name": "axem",
+            "namespace": "axemsolutions",
             "url": "https://registry.hub.docker.com"
         }
     ],

--- a/tests/core/test_data_management.py
+++ b/tests/core/test_data_management.py
@@ -182,7 +182,8 @@ def test_ConfigFile(mock_PurePath: MagicMock):
     assert local_dev_env_json._default_json == """{
     "registries": [
         {
-            "name": "axemsolutions",
+            "name": "axem",
+            "namespace": "axemsolutions",
             "url": "https://registry.hub.docker.com"
         }
     ],


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-292](https://axem.atlassian.net/browse/DEM-292)

## Description
Configs for Docker Hub registries must include a `name`, `namespace` and `url`
fields since v0.7.0, but the default config wasn't updated accordingly. 

## How Has This Been Tested?
Tested on Ubuntu 22.04. 
I have removed the ~/.config/axem directory and run the `dem list` command. DEM
recreated the removed directory with the correct config file.
