### PR TITLE
Missing link in docs fixed

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,7 @@ nav:
       - 'del-cat': 'commands/#dem-del-cat-name'
       - 'list-cat': 'commands/#dem-list-cat'
     - 'Registry Management':
-      - 'add-reg': 'commands/#dem-add-reg-name-url'
+      - 'add-reg': 'commands/#dem-add-reg-name-url-namespace'
       - 'del-reg': 'commands/#dem-del-reg-name'
       - 'list-reg': 'commands/#dem-list-reg'
     - 'Host Management':


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] All the test cases pass and new modifications in the production code are 100% covered.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-303](https://axem.atlassian.net/browse/DEM-303)

## Description
The `add-reg` command usage changed, so the reference in the navigation bar had 
to be updated.

## How Has This Been Tested?
The website has been generated with mkdocs on Ubuntu 22.04. The functionality 
was tested on the generated website.


[DEM-303]: https://axem.atlassian.net/browse/DEM-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ