### PR TITLE
Introduce option to use the system cert store for TLS authentication.

### DIFF
--- a/dem/__main__.py
+++ b/dem/__main__.py
@@ -25,6 +25,9 @@ def main() -> None:
         # Load the configuration file
         dem.cli.main.platform.config_file.update()
 
+        # Configure the Development Platform
+        dem.cli.main.platform.configure()
+
         # Load the Dev Env descriptors
         dem.cli.main.platform.load_dev_envs()
 

--- a/dem/core/platform.py
+++ b/dem/core/platform.py
@@ -1,7 +1,7 @@
 """Repesents the Development Platform. The platform resources can be accessed through this interface.  
 """
 
-import os
+import os, truststore
 from typing import Any, Generator
 from dem.core.core import Core
 from dem.core.properties import __supported_dev_env_major_version__
@@ -44,6 +44,11 @@ class Platform(Core):
 
         # Set this to true in the platform instance to get the tool image info from the registries
         self.get_tool_image_info_from_registries = False
+
+    def configure(self) -> None:
+        """ Configure the Development Platform."""
+        if self.config_file.use_native_system_cert_store:
+            truststore.inject_into_ssl()
 
     def load_dev_envs(self) -> None:
         """ Load the Development Environments from the dev_env.json file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,94 @@
+## registries
+
+The `registries` section of the configuration file is used to define the registries that DEM will 
+use to search for images. 
+
+**Default value:**
+
+```json
+"registries": [
+    {
+        "name": "axem",
+        "namespace": "axemsolutions",
+        "url": "https://registry.hub.docker.com"
+    }
+]
+```
+
+!!! info
+    The Registry Management commands can be used to manage the registries in the configuration file.  
+
+    - [`add-reg`](commands.md#dem-add-reg-name-url-namespace): Add a new registry to the configuration file.
+    - [`del-reg`](commands.md#dem-del-reg-name): Delete a registry from the configuration file.
+    - [`list-reg`](commands.md#dem-list-reg): List the registries in the configuration file.
+
+
+## catalogs
+
+The `catalogs` section of the configuration file is used to define the catalogs that DEM will use to
+search for Development Environment descriptors.
+
+** Default value: **
+
+```json
+"catalogs": [
+    {
+        "name": "axem",
+        "url": "https://axemsolutions.io/dem/dev_env_org.json"
+    }
+]
+```
+
+!!! info
+    The Catalog Management commands can be used to manage the catalogs in the configuration file.
+
+    - [`add-cat`](commands.md#dem-add-cat-name-url): Add a new catalog to the configuration file.
+    - [`del-cat`](commands.md#dem-del-cat-name): Delete a catalog from the configuration file.
+    - [`list-cat`](commands.md#dem-list-cat): List the catalogs in the configuration file.
+
+## hosts
+
+!!! warning
+    Remote hosts are not yet supported in DEM.
+
+The `hosts` section of the configuration file is used to define the hosts that DEM will use as 
+remote execution environments.
+
+**Default value:**
+
+```json
+"hosts": []
+```
+
+!!! info
+    The Host Management commands can be used to manage the hosts in the configuration file.
+
+    - [`add-host`](commands.md#dem-add-host-name-url): Add a new host to the configuration file.
+    - [`del-host`](commands.md#dem-del-host-name): Delete a host from the configuration file.
+    - [`list-host`](commands.md#dem-list-host): List the hosts in the configuration file.
+
+## http_request_timeout_s
+
+The `http_request_timeout_s` section of the configuration file is used to define the timeout for
+HTTP requests in seconds.
+
+**Default value:**
+
+```json
+"http_request_timeout_s": 2
+```
+
+## use_native_system_cert_store
+
+The `use_native_system_cert_store` section of the configuration file is used to define whether
+the native system certificate store should be used for HTTPS requests or the default one provided
+by the `certifi` package.
+
+**Default value:**
+
+```json
+"use_native_system_cert_store": false
+```
+
+!!! info
+    If the TLS authentication fails, try setting this value to `true`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
   - 'index.md'
   - 'installation.md'
   - 'basics.md'
+  - 'quickstart.md'
   - Commands: 
     - 'DevEnv Management':
       - 'add-task': 'commands/#dem-add-task-dev_env_name-task_name-command'
@@ -125,6 +126,6 @@ nav:
       - 'add-host': 'commands/#dem-add-host-name-address'
       - 'del-host': 'commands/#dem-del-host-name'
       - 'list-host': 'commands/#dem-list-host'
-  - 'quickstart.md'
+  - 'configuration.md'
   - 'design.md'
   - Join us on Discord  : 'https://discord.gg/3aHuJBNvrJ'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ dem = "dem.__main__:main"
 python = "^3.10"
 docker = "^7.0.0"
 readchar = "^4.0.6"
-requests = "^2.31.0"
+requests = "2.31.0"
 rich = "^13.7.1"
 typer = "^0.12.2"
+truststore = "^0.10.0"
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/core/test_data_management.py
+++ b/tests/core/test_data_management.py
@@ -170,10 +170,6 @@ def test_ConfigFile(mock_PurePath: MagicMock):
     test_path = "test_path"
     data_management.BaseJSON._config_dir = test_path
 
-    mock_registries = MagicMock()
-    mock_catalogs = MagicMock()
-    mock_hosts = MagicMock()
-
     # Run unit under test
     local_dev_env_json = data_management.ConfigFile()
 
@@ -194,13 +190,15 @@ def test_ConfigFile(mock_PurePath: MagicMock):
         }
     ],
     "hosts": [],
-    "http_request_timeout_s": 2
+    "http_request_timeout_s": 2,
+    "use_native_system_cert_store": false
 }"""
 
     mock_PurePath.assert_called_once_with(test_path + "/config.json")
 
+@patch.object(data_management.BaseJSON, "flush")
 @patch.object(data_management.BaseJSON, "update")
-def test_ConfigFile_update(mock_update: MagicMock) -> None:
+def test_ConfigFile_update(mock_update: MagicMock, mock_flush: MagicMock) -> None:
     # Test setup
     test_config_file = data_management.ConfigFile()
     test_registry = MagicMock()
@@ -224,28 +222,7 @@ def test_ConfigFile_update(mock_update: MagicMock) -> None:
     assert test_config_file.http_request_timeout_s == test_http_request_timeout_s
 
     mock_update.assert_called_once()
-
-@patch.object(data_management.BaseJSON, "update")
-def test_ConfigFile_update_missing_http_request_timeout_s(mock_update: MagicMock) -> None:
-    # Test setup
-    test_config_file = data_management.ConfigFile()
-    test_registry = MagicMock()
-    test_catalog = MagicMock()
-    test_host = MagicMock()
-    test_config_file.deserialized = {
-        "registries": [test_registry],
-        "catalogs": [test_catalog],
-        "hosts": [test_host],
-    }
-
-    with pytest.raises(data_management.DataStorageError) as e:
-        # Run unit under test
-        test_config_file.update()
-
-    # Check expectations
-    assert "Invalid file: The http_request_timeout_s is not set in the config.json file." == str(e.value)
-
-    mock_update.assert_called_once()
+    mock_flush.assert_called_once()
 
 @patch.object(data_management.BaseJSON, "update")
 def test_ConfigFile_update_JSONDecodeError(mock_update: MagicMock) -> None:


### PR DESCRIPTION
## Type Of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-309](https://axem.atlassian.net/browse/DEM-309)

## Description
DEM always used the default cacert.pem file for authentication provided by the certifi module. Introducing a new config option to make DEM use the operating system's certificate store.

Enhancing configuration management by adding default options and loading logic for registries, catalogs, hosts, certs and timeout settings. Introducing platform configuration method and updating documentation and test cases.

## How Has This Been Tested?
Tested on Ubuntu 22.04, by both using the system and the certifi certifications.


[DEM-309]: https://axem.atlassian.net/browse/DEM-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ