### PR TITLE
info and assign commands handle the custom and docker run tasks

### DIFF
--- a/dem/cli/main.py
+++ b/dem/cli/main.py
@@ -103,7 +103,7 @@ def autocomplete_task_name(ctx: typer.Context, incomplete: str) -> Generator:
     if platform is not None and dev_env_name is not None:
         for dev_env in platform.local_dev_envs:
             if dev_env.name == dev_env_name:
-                for task_name in dev_env.tasks:
+                for task_name in dev_env.custom_tasks:
                     if task_name.startswith(incomplete) or (incomplete == ""):
                         yield task_name
 

--- a/dem/core/commands/info_cmd.py
+++ b/dem/core/commands/info_cmd.py
@@ -64,7 +64,7 @@ def print_tasks_info_table(dev_env: DevEnv) -> None:
     task_table.add_column("Task")
     task_table.add_column("Command")
 
-    for task_name, command in dev_env.tasks.items():
+    for task_name, command in dev_env.custom_tasks.items():
         task_table.add_row(task_name, command)
 
     stdout.print(task_table)
@@ -78,7 +78,7 @@ def print_local_dev_env_info(platform: Platform, dev_env: DevEnv) -> None:
     """
     stdout.print(f"\n[bold]Development Environment: {dev_env.name}[/]\n")
     print_tools_info_table(dev_env, True, platform)
-    if dev_env.tasks:
+    if dev_env.custom_tasks:
         print_tasks_info_table(dev_env)
 
     if dev_env.is_installed and not dev_env.is_installation_correct():
@@ -114,7 +114,7 @@ def print_cat_dev_env_info(dev_env: DevEnv, cat_name: str) -> None:
     stdout.print(f"\n[bold]Development Environment: {dev_env.name}[/]\n")
     stdout.print(f"Catalog: {cat_name}\n")
     print_tools_info_table(dev_env, False)
-    if dev_env.tasks:
+    if dev_env.custom_tasks:
         print_tasks_info_table(dev_env)
 
 def cat_dev_env_info(platform: Platform, dev_env_name: str, selected_cats: list[str]) -> None:

--- a/dem/core/commands/run_cmd.py
+++ b/dem/core/commands/run_cmd.py
@@ -53,10 +53,10 @@ def execute(platform: Platform, dev_env_name: str, task_name: str, cmd_extra_arg
 
     dev_env_health_check(platform, dev_env)
 
-    if task_name in dev_env.tasks:
-        command = dev_env.tasks[task_name]
+    if task_name in dev_env.custom_tasks:
+        command = dev_env.custom_tasks[task_name]
     else:
-        for advanced_task in dev_env.advanced_tasks:
+        for advanced_task in dev_env.docker_run_tasks:
             if advanced_task["name"] == task_name:
                 command = "docker run"
                 if advanced_task["rm"] == True:

--- a/dem/core/dev_env.py
+++ b/dem/core/dev_env.py
@@ -38,8 +38,8 @@ class DevEnv():
         self.name: str = descriptor["name"]
         self.tool_image_descriptors: list[dict[str, str]] = descriptor["tools"]
         self.tool_images: list[ToolImage] = []
-        self.tasks: dict[str, str] = descriptor.get("tasks", {})
-        self.advanced_tasks: list[dict] = descriptor.get("advanced_tasks", [])
+        self.custom_tasks: list[dict] = descriptor.get("custom_tasks", [])
+        self.docker_run_tasks: list[dict] = descriptor.get("docker_run_tasks", [])
         if "True" == descriptor.get("installed", "False"):
             self.is_installed = True
         else:
@@ -72,7 +72,7 @@ class DevEnv():
                 task_name -- the task name
                 command -- the command
         """
-        self.tasks[task_name] = command
+        self.custom_tasks[task_name] = command
 
     def del_task(self, task_name: str) -> None:
         """ Delete a task from the Development Environment.
@@ -83,8 +83,8 @@ class DevEnv():
             Exceptions:
                 KeyError -- if the task doesn't exist
         """
-        if task_name in self.tasks:
-            del self.tasks[task_name]
+        if task_name in self.custom_tasks:
+            del self.custom_tasks[task_name]
         else:
             raise KeyError(f"Task [bold]{task_name}[/] not found.")
 
@@ -102,7 +102,7 @@ class DevEnv():
                 return True
         return False
 
-    def get_deserialized(self, omit_is_installed: bool = False) -> dict[str, str]:
+    def get_deserialized(self, omit_is_installed: bool = False) -> dict:
         """ Create the deserialized json. 
         
             Return the Dev Env as a dict.
@@ -110,7 +110,8 @@ class DevEnv():
         dev_env_json_deserialized: dict = {
             "name": self.name,
             "tools": self.tool_image_descriptors,
-            "tasks": self.tasks
+            "custom_tasks": self.custom_tasks,
+            "docker_run_tasks": self.docker_run_tasks
         }
         
         if omit_is_installed is False:

--- a/tests/core/test_dev_env.py
+++ b/tests/core/test_dev_env.py
@@ -29,7 +29,7 @@ def test_DevEnv() -> None:
     # Check expectations
     assert test_dev_env.name is test_descriptor["name"]
     assert test_dev_env.tool_image_descriptors is test_descriptor["tools"]
-    assert test_dev_env.tasks is test_descriptor["tasks"]
+    assert test_dev_env.custom_tasks is test_descriptor["tasks"]
 
 @patch("dem.core.dev_env.json.load")
 @patch("dem.core.dev_env.open")
@@ -60,7 +60,7 @@ def test_DevEnv_with_descriptor_path(mock_path_exists: MagicMock, mock_open: Mag
     assert test_dev_env.name is test_descriptor["name"]
     assert test_dev_env.tool_image_descriptors is test_descriptor["tools"]
     assert test_dev_env.is_installed is True
-    assert test_dev_env.tasks is test_descriptor["tasks"]
+    assert test_dev_env.custom_tasks is test_descriptor["tasks"]
 
     mock_path_exists.assert_called_once_with(test_descriptor_path)
     mock_open.assert_called_once_with(test_descriptor_path, "r")
@@ -166,7 +166,7 @@ def test_DevEnv_add_task() -> None:
     test_dev_env.add_task(test_task_name, test_command)
 
     # Check expectations
-    assert test_dev_env.tasks[test_task_name] == test_command
+    assert test_dev_env.custom_tasks[test_task_name] == test_command
 
 def test_DevEnv_del_task() -> None:
     # Test setup
@@ -188,7 +188,7 @@ def test_DevEnv_del_task() -> None:
     test_dev_env.del_task(test_task_name)
 
     # Check expectations
-    assert test_task_name not in test_dev_env.tasks
+    assert test_task_name not in test_dev_env.custom_tasks
 
 def test_DevEnv_del_task_not_existing() -> None:
     # Test setup


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-324](https://axem.atlassian.net/browse/DEM-324)

## Description
The DevEnv descriptor now can contain two task types: `docker run` and custom. 
The `assign` and `init` commands updated to manage these new fields.

## How Has This Been Tested?
Testen on Ubuntu 22.04.


[DEM-324]: https://axem.atlassian.net/browse/DEM-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ