### PR TITLE
Add DevEnv setting to enable running docker containers as the current user.

### DIFF
--- a/dem/api/main.py
+++ b/dem/api/main.py
@@ -1,5 +1,6 @@
 """ This module contains the FastAPI application that serves as the API for the DEM. """
 # dem/api/main.py
+
 from fastapi import HTTPException
 from pydantic import BaseModel
 from dem.core.platform import Platform
@@ -8,12 +9,28 @@ from dem.core.commands.run_cmd import execute as run_execute
 platform: Platform | None = None
 
 class RunCommandRequest(BaseModel):
+    """ Request model for the run command. 
+
+        Attributes:
+            dev_env_name -- the name of the Development Environment to run the task in
+            task_name -- the name of the task to run
+            extra_args -- the arguments to pass to the task
+    """
     dev_env_name: str
     task_name: str
     extra_args: str
 
 @Platform.fastapi_app.post("/run")
 def run_command(request: RunCommandRequest) -> dict:
+    """ Run the given task in the given Development Environment.
+    
+        Args:
+            request -- the request containing the Development Environment name, the task name, 
+                        and the extra arguments
+            
+        Returns:
+            a dictionary containing the status and message
+    """
     dev_env_name = request.dev_env_name
     task_name = request.task_name
     extra_args = request.extra_args

--- a/dem/core/commands/info_cmd.py
+++ b/dem/core/commands/info_cmd.py
@@ -52,6 +52,8 @@ def print_tools_info_table(dev_env: DevEnv, is_local: bool, platform: Platform =
     if is_local:
         print_status(platform, dev_env)
 
+        stdout.print(f"Tasks run as the current user: {dev_env.run_tasks_as_current_user}\n")
+
     stdout.print(tool_info_table)
 
 def print_tasks_info_table(dev_env: DevEnv) -> None:

--- a/dem/core/commands/run_cmd.py
+++ b/dem/core/commands/run_cmd.py
@@ -24,6 +24,39 @@ def dev_env_health_check(platform: Platform, dev_env: DevEnv) -> None:
         platform.install_dev_env(dev_env)
         stdout.print(f"[green]DEM successfully fixed the {dev_env.name} Development Environment![/]")
 
+def compose_docker_run_task(platform: Platform, dev_env: DevEnv, docker_run_task: dict, 
+                            cmd_extra_args: str) -> str:
+    """ Compose the docker run command for a task.
+    
+        Args:
+            platform -- the Platform
+            dev_env -- the Development Environment
+            docker_run_task -- description of the task
+            cmd_extra_args -- the extra arguments for the command
+
+        Returns:
+            the composed docker run command
+    """
+    command = "docker run"
+    if docker_run_task["rm"] == True:
+        command += " --rm"
+
+    if docker_run_task["mount_workdir"] == True:
+        pass
+
+    if dev_env.run_tasks_as_current_user:
+        command += " -u $(id -u):$(id -g)"
+
+    command += f" {docker_run_task['extra_args']} {docker_run_task['image']}"
+
+    if docker_run_task['command'] or cmd_extra_args:
+        command += f" /bin/bash -c \"{docker_run_task['command']} {cmd_extra_args}\""
+
+    if docker_run_task['enable_api'] == True:
+        platform.api_server.start()
+    
+    return command
+
 def execute(platform: Platform, dev_env_name: str, task_name: str, cmd_extra_args: str) -> None:
     """ Run a task in a Development Environment.
     
@@ -31,6 +64,7 @@ def execute(platform: Platform, dev_env_name: str, task_name: str, cmd_extra_arg
             platform -- the Platform
             dev_env_name -- the Development Environment name
             task_name -- the task name
+            cmd_extra_args -- the extra arguments for the command
 
         Raises:
             typer.Abort -- if the Development Environment has missing tool images
@@ -56,22 +90,9 @@ def execute(platform: Platform, dev_env_name: str, task_name: str, cmd_extra_arg
     if task_name in dev_env.custom_tasks:
         command = dev_env.custom_tasks[task_name]
     else:
-        for advanced_task in dev_env.docker_run_tasks:
-            if advanced_task["name"] == task_name:
-                command = "docker run"
-                if advanced_task["rm"] == True:
-                    command += " --rm"
-
-                if advanced_task["mount_workdir"] == True:
-                    pass
-
-                command += f" {advanced_task['extra_args']} {advanced_task['image']}"
-
-                if advanced_task['command'] or cmd_extra_args:
-                    command += f" /bin/bash -c \"{advanced_task['command']} {cmd_extra_args}\""
-
-                if advanced_task['enable_api'] == True:
-                    platform.api_server.start()
+        for docker_run_task in dev_env.docker_run_tasks:
+            if docker_run_task["name"] == task_name:
+                command = compose_docker_run_task(platform, dev_env, docker_run_task, cmd_extra_args)
                 break
         else:
             stderr.print(f"[red]Error: Task [bold]{task_name}[/bold] not found in Development Environment [bold]{dev_env_name}[/bold]![/]")

--- a/dem/core/dev_env.py
+++ b/dem/core/dev_env.py
@@ -40,6 +40,7 @@ class DevEnv():
         self.tool_images: list[ToolImage] = []
         self.custom_tasks: list[dict] = descriptor.get("custom_tasks", [])
         self.docker_run_tasks: list[dict] = descriptor.get("docker_run_tasks", [])
+        self.run_tasks_as_current_user: bool = descriptor.get("run_tasks_as_current_user", False)
         if "True" == descriptor.get("installed", "False"):
             self.is_installed = True
         else:
@@ -111,7 +112,8 @@ class DevEnv():
             "name": self.name,
             "tools": self.tool_image_descriptors,
             "custom_tasks": self.custom_tasks,
-            "docker_run_tasks": self.docker_run_tasks
+            "docker_run_tasks": self.docker_run_tasks,
+            "run_tasks_as_current_user": self.run_tasks_as_current_user
         }
         
         if omit_is_installed is False:


### PR DESCRIPTION
## Type Of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [ ] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [ ] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-320](https://axem.atlassian.net/browse/DEM-320)

## Description
New setting added for the DevEnv descriptors, called `run_tasks_as_current_user`.
The setting is a boolean:
- true: the container runs with the same user (uid, gid) as the current user who
started the DEM task
- false: by default, the container runs as root, but with the `extra_args` 
option for the tasks the uid and gid can be set

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-320]: https://axem.atlassian.net/browse/DEM-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ