### PR TITLE
Add DevEnv specific network creation

### DIFF
--- a/dem/core/commands/run_cmd.py
+++ b/dem/core/commands/run_cmd.py
@@ -47,7 +47,10 @@ def compose_docker_run_task(platform: Platform, dev_env: DevEnv, docker_run_task
     if dev_env.run_tasks_as_current_user:
         command += " -u $(id -u):$(id -g)"
 
-    command += f" {docker_run_task['extra_args']} {docker_run_task['image']}"
+    if dev_env.enable_docker_network and docker_run_task['connect_to_network']:
+        command += f" --network {dev_env.name}"
+
+    command += f" --name {docker_run_task['name']} {docker_run_task['extra_args']} {docker_run_task['image']}"
 
     if docker_run_task['command'] or cmd_extra_args:
         command += f" /bin/bash -c \"{docker_run_task['command']} {cmd_extra_args}\""

--- a/dem/core/container_engine.py
+++ b/dem/core/container_engine.py
@@ -116,3 +116,25 @@ class ContainerEngine(Core):
             self.user_output.msg(f"[yellow]The {image} doesn't exist. Unable to remove it.[/]\n")
         except docker.errors.APIError:
             raise ContainerEngineError(f"The {image} is used by a container. Unable to remove it.\n")
+
+    def create_network(self, network_name: str) -> None:
+        """ Create a Docker network.
+
+            Args:
+                network_name -- the name of the network
+        """
+        self._docker_client.networks.create(network_name)
+
+    def remove_network(self, network_name: str) -> None:
+        """ Remove a Docker network.
+
+            Args:
+                network_name -- the name of the network
+        """
+        try:
+            network = self._docker_client.networks.get(network_name)
+        except docker.errors.NotFound:
+            self.user_output.msg(f"[yellow]The {network_name} doesn't exist. Unable to remove it.[/]\n")
+            return
+
+        network.remove()

--- a/dem/core/dev_env.py
+++ b/dem/core/dev_env.py
@@ -41,6 +41,7 @@ class DevEnv():
         self.custom_tasks: list[dict] = descriptor.get("custom_tasks", [])
         self.docker_run_tasks: list[dict] = descriptor.get("docker_run_tasks", [])
         self.run_tasks_as_current_user: bool = descriptor.get("run_tasks_as_current_user", False)
+        self.enable_docker_network: bool = descriptor.get("enable_docker_network", False)
         if "True" == descriptor.get("installed", "False"):
             self.is_installed = True
         else:
@@ -113,7 +114,8 @@ class DevEnv():
             "tools": self.tool_image_descriptors,
             "custom_tasks": self.custom_tasks,
             "docker_run_tasks": self.docker_run_tasks,
-            "run_tasks_as_current_user": self.run_tasks_as_current_user
+            "run_tasks_as_current_user": self.run_tasks_as_current_user,
+            "enable_docker_network": self.enable_docker_network
         }
         
         if omit_is_installed is False:

--- a/dem/core/platform.py
+++ b/dem/core/platform.py
@@ -177,6 +177,9 @@ class Platform(Core):
                 except ContainerEngineError as e:
                     raise PlatformError(f"Dev Env install failed. --> {str(e)}")
 
+        if dev_env_to_install.enable_docker_network:
+            self.container_engine.create_network(dev_env_to_install.name)
+
         dev_env_to_install.is_installed = True
         self.flush_dev_env_properties()
 
@@ -217,6 +220,9 @@ class Platform(Core):
                 raise PlatformError(f"Dev Env uninstall failed. --> {str(e)}")
             else:
                 yield f"The {tool_image_name} image has been removed."
+
+        if dev_env_to_uninstall.enable_docker_network:
+            self.container_engine.remove_network(dev_env_to_uninstall.name)
             
         dev_env_to_uninstall.is_installed = False
         if self.default_dev_env_name == dev_env_to_uninstall.name:

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -5,7 +5,7 @@ title: The basic concepts of Development Environment Management
 
 ## What is a Development Environment?
 A set of software tools used for a specific development project is called a **Development
-Environment**. These tools can include the build system, debugger, test framework, and more.
+Environment**, or DevEnv for short. These tools can include the build system, debugger, test framework, and more.
 
 ## A Container Image
 A container image is a set of **software components alongside its dependencies**, 

--- a/docs/dev_env_settings.md
+++ b/docs/dev_env_settings.md
@@ -1,0 +1,26 @@
+---
+title: Development Environment Settings
+---
+
+## run_tasks_as_current_user
+
+Type: `bool`
+
+Default: `false`
+
+When set to `true`, DEM will run tasks as the current user, with the same UID and GID.
+By default, tasks are run as the root user, but the UID and GID can be set using the `-u` as extra
+arguments.
+
+## enable_docker_network
+
+Type: `bool`
+
+Default: `false`
+
+When set to `true`, DEM will enable the Docker network for the container. This allows the container 
+to communicate with other containers on the same network.
+
+!!! note
+    This setting only enables the network. To make a container connected to this network, the 
+    approriate settings must enabled in the task settings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,8 @@
 
 ## **What is DEM?**
 
-DEM (Development Environment Manager) is an **open-source command line tool for setting up, managing, and sharing Development Environments**.
+DEM (Development Environment Manager) is an **open-source command line tool for setting up, 
+managing, and sharing Development Environments**.
 
 DEM empowers developers to **create, modify, and maintain consistent Development Environments with ease**.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
   - 'installation.md'
   - 'basics.md'
   - 'quickstart.md'
+  - 'dev_env_settings.md'
   - Commands: 
     - 'DevEnv Management':
       - 'add-task': 'commands/#dem-add-task-dev_env_name-task_name-command'


### PR DESCRIPTION
## Type Of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-319](https://axem.atlassian.net/browse/DEM-319)

## Description
New DevEnv wide config option added to enable a DevEnv specific network.
It can be set for the specific task to connect to this network or not.

## How Has This Been Tested?
Tested on Ubuntu 22.04


[DEM-319]: https://axem.atlassian.net/browse/DEM-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ