### PR TITLE
Tool images can be installed on remote hosts

### DIFF
--- a/dem/__main__.py
+++ b/dem/__main__.py
@@ -25,9 +25,6 @@ def main() -> None:
     Core.set_user_output(TUIUserOutput())
 
     try:
-        # Load the configuration file
-        dem.cli.main.platform.config_file.update()
-
         # Configure the Development Platform
         dem.cli.main.platform.configure()
 

--- a/dem/core/commands/create_cmd.py
+++ b/dem/core/commands/create_cmd.py
@@ -74,7 +74,7 @@ def create_dev_env(platform: Platform, dev_env_name: str) -> None:
         "name": dev_env_name,
         "tools": convert_to_tool_descriptor(selected_tool_images),
         "custom_tasks": [],
-        "docker_run_tasks": [],
+        "docker_tasks": [],
         "run_tasks_as_current_user": False,
         "enable_docker_network": False,
         "installed": "False"

--- a/dem/core/commands/install_cmd.py
+++ b/dem/core/commands/install_cmd.py
@@ -2,7 +2,8 @@
 # dem/cli/command/install_cmd.py
 
 from dem.core.dev_env import DevEnv
-from dem.core.platform import Platform, PlatformError
+from dem.core.platform import Platform
+from dem.core.exceptions import DevEnvError, PlatformError
 from dem.cli.console import stderr, stdout
 
 def execute(platform: Platform, dev_env_name: str) -> None:
@@ -24,8 +25,9 @@ def execute(platform: Platform, dev_env_name: str) -> None:
         stderr.print(f"[red]Error: The {dev_env_name} Development Environment is already installed.[/]")
     else:
         try:
+            dev_env_to_install.start_engines()
             platform.install_dev_env(dev_env_to_install)            
-        except PlatformError as e:
+        except (PlatformError, DevEnvError) as e:
             stderr.print(f"[red]{e}[/]")
         else:
             stdout.print(f"[green]Successfully installed the {dev_env_name}![/]")

--- a/dem/core/commands/list_cmd.py
+++ b/dem/core/commands/list_cmd.py
@@ -4,6 +4,7 @@
 from dem.core.platform import Platform
 from dem.core.dev_env import DevEnv
 from dem.core.dev_env_catalog import DevEnvCatalog
+from dem.core.exceptions import DevEnvError
 from dem.cli.console import stdout, stderr
 from rich.table import Table
 from typing import List
@@ -19,6 +20,10 @@ def add_dev_env_info_to_table(platform: Platform, table: Table, dev_env: DevEnv)
     installed_column = ""
     default_column = ""
     if dev_env.is_installed:
+        try:
+            dev_env.start_engines()
+        except DevEnvError as e:
+            stderr.print(f"[red]{e}[/]")
         dev_env.assign_tool_image_instances(platform.tool_images)
         installed_column = "[green]✓[/]"
         

--- a/dem/core/commands/list_host_cmd.py
+++ b/dem/core/commands/list_host_cmd.py
@@ -8,29 +8,32 @@ from rich.table import Table
 def execute(platform: Platform) -> None:
     """ List available Hosts.
     
-    Usage: dem list-host
-    
-    """
+        Usage: dem list-host
+        
+        Ideally, if 'remote_hosts' is populated, it should look something like:
+        remote_hosts = [
+                    {'name': 'host1', 'address': 'ip_address1'}
+                    {'name': 'host2', 'address': 'ip_address2'}
+                    .... and so on
+                ]
+        if there are no hosts:
+        remote_hosts = [  ]
 
-    hosts: list[dict] = platform.hosts.list_host_configs()
+        Args:
+            platform -- the platform
     """
-    Ideally, if 'hosts' is populated, it should look something like:
-    hosts = [
-                {'name': 'host1', 'address': 'ip_address1'}
-                {'name': 'host2', 'address': 'ip_address2'}
-                .... and so on
-            ]
-    if there are no hosts:
-    hosts = [  ]
-    """
+    remote_hosts: list[dict] = platform.hosts.list_host_configs()
+
+    if not remote_hosts:
+        stdout.print("[yellow]No available remote hosts![/]")
+
     table = Table()
     table.add_column("name")
     table.add_column("address")
+    table.add_row(platform.hosts.local.name, platform.hosts.local.address)
+    for host in remote_hosts:
+        table.add_row(host['name'], host['address'])
 
-    if not hosts:
-        stdout.print("[yellow]No available remote hosts![/]")
-    else:
-        for host in hosts:
-            table.add_row(host['name'], host['address'])
-
-        stdout.print(table)
+    stdout.print(table)
+    stdout.print("Note: The 'local' host is the host where the DEM Core is running," + \
+                 "and is always available.")

--- a/dem/core/commands/run_cmd.py
+++ b/dem/core/commands/run_cmd.py
@@ -93,7 +93,7 @@ def execute(platform: Platform, dev_env_name: str, task_name: str, cmd_extra_arg
     if task_name in dev_env.custom_tasks:
         command = dev_env.custom_tasks[task_name]
     else:
-        for docker_run_task in dev_env.docker_run_tasks:
+        for docker_run_task in dev_env.docker_task_descriptors:
             if docker_run_task["name"] == task_name:
                 command = compose_docker_run_task(platform, dev_env, docker_run_task, cmd_extra_args)
                 break

--- a/dem/core/container_engine.py
+++ b/dem/core/container_engine.py
@@ -3,15 +3,28 @@
 
 from dem.core.core import Core
 from dem.core.exceptions import ContainerEngineError
-import docker
+from docker import DockerClient
 import docker.errors
 
 class ContainerEngine(Core):
     """ Operations on the Docker Container Engine."""
 
-    def __init__(self) -> None:
+    def __init__(self, docker_server_url: str) -> None:
         """ Init the class."""
-        self._docker_client = docker.from_env()
+        self._docker_client: DockerClient | None = None
+        self._docker_server_url: str = docker_server_url
+    
+    def start(self) -> None:
+        """ Start the Docker client.
+
+            Raises:
+                ContainerEngineError -- if the Docker client can't be started
+        """
+        if self._docker_client is None:
+            try:
+                self._docker_client = DockerClient(base_url=self._docker_server_url, version="auto")
+            except docker.errors.DockerException as e:
+                raise ContainerEngineError(f"Unable to connect to the Docker Engine: {e}")
 
     def get_local_tool_images(self) -> list[str]:
         """ Get local tool images.

--- a/dem/core/exceptions.py
+++ b/dem/core/exceptions.py
@@ -48,3 +48,19 @@ class CatalogError(Exception):
 
     def __init__(self, message: str) -> None:
         super().__init__(self.base_message + message)
+
+class TaskError(Exception):
+    """ Raised when there is a problem with a task. """
+
+    base_message = "Task error: "
+
+    def __init__(self, message: str) -> None:
+        super().__init__(self.base_message + message)
+
+class DevEnvError(Exception):
+    """ Raised when there is a problem with a Development Environment. """
+
+    base_message = "Development Environment error: "
+
+    def __init__(self, message: str) -> None:
+        super().__init__(self.base_message + message)

--- a/dem/core/task.py
+++ b/dem/core/task.py
@@ -1,0 +1,68 @@
+""" This module contains the different task types. """
+# dem/core/task.py
+
+from dem.core.hosts import Hosts
+from dem.core.exceptions import TaskError
+
+class Task():
+    """ A Task. """
+    def __init__(self, task_descriptor: dict) -> None:
+        """ Initialize the Task class.
+        
+            Args:
+                task_descriptor -- The description of the task.
+        """
+        self.descriptor: dict = task_descriptor
+
+class DockerTask(Task):
+    """ A Docker Task. """
+    def __init__(self, task_descriptor: dict, hosts: Hosts) -> None:
+        """ Initialize the DockerTask class.
+        
+            Args:
+                task_descriptor -- The description of the task.
+                hosts -- The available hosts.
+        """
+        super().__init__(task_descriptor)
+        self.name: str = task_descriptor["name"]
+        self.rm: bool = task_descriptor["rm"]
+        self.mount_workdir: bool = task_descriptor["mount_workdir"]
+        self.connect_to_network: bool = task_descriptor["connect_to_network"]
+        self.extra_args: str = task_descriptor["extra_args"]
+        self.image: str = task_descriptor["image"]
+        self.command: str = task_descriptor["command"]
+        self.enable_api: bool = task_descriptor["enable_api"]
+        self.host_name: str = task_descriptor["host_name"]
+
+        if self.host_name == "local":
+            self.host = hosts.local
+        else:
+            try:
+                self.host = hosts.remotes[self.host_name]
+            except KeyError:
+                raise TaskError(f"Host {self.host_name} not available.")
+
+    # def run(self, hosts: Hosts, cmd_extra_args: str) -> None:
+    #     host: Host = hosts.remotes[self.host_name]
+    #     command = "docker run"
+    #     if self.rm == True:
+    #         command += " --rm"
+
+    #     if self.mount_workdir == True:
+    #         pass
+
+    #     if host.container_engine.run_tasks_as_current_user:
+    #         command += " -u $(id -u):$(id -g)"
+
+    #     if host.container_engine.enable_docker_network and self.connect_to_network:
+    #         command += f" --network {host.name}"
+
+    #     command += f" --name {self.name} {self.extra_args} {self.image}"
+
+    #     if self.command or cmd_extra_args:
+    #         command += f" /bin/bash -c \"{self.command} {cmd_extra_args}\""
+
+    #     if self.enable_api == True:
+    #         host.container_engine.api_server.start()
+
+    #     print(command)  

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -270,11 +270,8 @@ command.
 
 **Description:**
 
-Install the selected Development Environment. DEM pulls all the required containerized tools (which 
-are not yet available on the host PC) from the registry and install the Development Environment 
-locally. If the same Development Environment is already installed, but the installation is not 
-complete, the missing tool images get obtained from the registry.
-
+Install the selected Development Environment. DEM pulls all the required containerized tools to the 
+appropriate hosts defined by the assigned tasks. 
 
 **Arguments:**
 

--- a/tests/core/test_dev_env.py
+++ b/tests/core/test_dev_env.py
@@ -119,7 +119,7 @@ def test_DevEnv_assign_tool_image_instances() -> None:
     }
     test_dev_env = dev_env.DevEnv(test_descriptor)
     mock_previous_tool_images = MagicMock()
-    test_dev_env.tool_images = [mock_previous_tool_images]
+    test_dev_env.assigned_tool_images = [mock_previous_tool_images]
 
     mock_tool_images = MagicMock()
     mock_tool_image1 = MagicMock()
@@ -141,8 +141,8 @@ def test_DevEnv_assign_tool_image_instances() -> None:
     test_dev_env.assign_tool_image_instances(mock_tool_images)
 
     # Check expectations
-    assert len(test_dev_env.tool_images) == 3
-    for tool_image in test_dev_env.tool_images:
+    assert len(test_dev_env.assigned_tool_images) == 3
+    for tool_image in test_dev_env.assigned_tool_images:
         assert tool_image is mock_tool_images.all_tool_images[tool_image.name]
 
 def test_DevEnv_add_task() -> None:
@@ -224,7 +224,7 @@ def test_DevEnv_is_installation_correct_true(mock___init__: MagicMock) -> None:
     mock_tool_image1.availability = dev_env.ToolImage.LOCAL_AND_REGISTRY
     mock_tool_image2 = MagicMock()
     mock_tool_image2.availability = dev_env.ToolImage.LOCAL_ONLY
-    test_dev_env.tool_images = [
+    test_dev_env.assigned_tool_images = [
         mock_tool_image1,
         mock_tool_image2
     ]
@@ -249,7 +249,7 @@ def test_DevEnv_is_installation_correct_false(mock___init__: MagicMock) -> None:
     mock_tool_image1.availability = dev_env.ToolImage.NOT_AVAILABLE
     mock_tool_image2 = MagicMock()
     mock_tool_image2.availability = dev_env.ToolImage.LOCAL_ONLY
-    test_dev_env.tool_images = [
+    test_dev_env.assigned_tool_images = [
         mock_tool_image1,
         mock_tool_image2
     ]
@@ -274,7 +274,7 @@ def test_DevEnv_is_installation_correct_not_istalled(mock___init__: MagicMock) -
     mock_tool_image1.availability = dev_env.ToolImage.REGISTRY_ONLY
     mock_tool_image2 = MagicMock()
     mock_tool_image2.availability = dev_env.ToolImage.LOCAL_ONLY
-    test_dev_env.tool_images = [
+    test_dev_env.assigned_tool_images = [
         mock_tool_image1,
         mock_tool_image2
     ]

--- a/tests/core/test_hosts.py
+++ b/tests/core/test_hosts.py
@@ -43,12 +43,12 @@ def test_Hosts(mock_config_file) -> None:
     test_hosts = hosts.Hosts()
 
     # Check expectations
-    assert len(test_hosts.hosts) == len(test_host_configs)
+    assert len(test_hosts.remotes) == len(test_host_configs)
 
     for index, test_host_config in enumerate(test_host_configs):
-        assert test_hosts.hosts[index].name == test_host_config["name"]
-        assert test_hosts.hosts[index].address == test_host_config["address"]
-        assert test_hosts.hosts[index].config == test_host_config
+        assert test_hosts.remotes[index].name == test_host_config["name"]
+        assert test_hosts.remotes[index].address == test_host_config["address"]
+        assert test_hosts.remotes[index].config == test_host_config
 
 @patch.object(hosts.Core, "config_file")
 @patch.object(hosts.Core, "user_output")
@@ -70,7 +70,7 @@ def test_Hosts_error(mock_Host: MagicMock, mock_user_output: MagicMock, mock_con
     test_hosts = hosts.Hosts()
 
     # Check expectations
-    assert len(test_hosts.hosts) == 0
+    assert len(test_hosts.remotes) == 0
 
     mock_Host.assert_called_once_with(test_host_config[0])
     mock_user_output.assert_has_calls([
@@ -140,14 +140,14 @@ def test_Hosts_delete_host(mock___init__: MagicMock, mock_config_file: MagicMock
     mock_host.config = test_host_config
 
     test_hosts = hosts.Hosts()
-    test_hosts.hosts = [mock_host]
+    test_hosts.remotes = [mock_host]
 
     # Run unit under test
     test_hosts.delete_host(test_host_config)
 
     # Check expectations
     assert test_host_config not in mock_config_file.hosts
-    assert mock_host not in test_hosts.hosts
+    assert mock_host not in test_hosts.remotes
 
     mock___init__.assert_called_once()
     mock_config_file.flush.assert_called_once()


### PR DESCRIPTION
## Type Of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-233](https://axem.atlassian.net/browse/DEM-233)
#214

## Description
Tool images can be installed on remote hosts defined by the tasks assigned to the DevEnv. This is the first step to managing hybrid DevEnvs.

