### PR TITLE
Tool images can be uninstalled from remote hosts

### DIFF
--- a/dem/core/hosts.py
+++ b/dem/core/hosts.py
@@ -20,18 +20,16 @@ class Host():
 class Hosts(Core):
     """ List of the available Hosts. """
     def __init__(self) -> None:
-        """ Init the class with the host configurations.
-
-            Args:
-                config_file -- contains the host configurations
-            """
+        """ Init the class with the host configurations. """
         self.remotes: dict[str, Host] = {}
 
+        # The local host is always available.
         local_host_config = {
             "name": "local",
             "address": "unix://var/run/docker.sock"
         }
         self.local = Host(local_host_config)
+        self.local.container_engine.start()
 
         for host_config in self.config_file.hosts:
             host = Host(host_config)
@@ -73,4 +71,7 @@ class Hosts(Core):
 
             Return with the host instance. If the host doesn't exist, return with None.
         """
-        return self.remotes.get(host_name, None)
+        if host_name == "local":
+            return self.local
+        else: 
+            return self.remotes.get(host_name, None)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -441,8 +441,10 @@ Development Environment.
 
 Uninstall the selected Development Environment.
 
-Sets the installed flag to False. DEM checks whether 
-a tool image is required or not by any of the remaining installed local Development Environments. In case the tool image is not required anymore, the DEM tries to delete it. 
+Sets the installed flag to False. DEM checks whether a tool image of the DevEnv is required or not 
+by any of the remaining installed Development Environments on the appropriate hosts. In case the 
+tool image is not required anymore by any other DevEnv, the DEM tries to delete it from the host 
+where it is installed. 
 
 **Arguments:**
 


### PR DESCRIPTION
## Type Of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Any modification in the test cases
- [x] Any modification in the documentation

### Checklist:

- [x] I have read and followed the [contribution guideline](https://github.com/axem-solutions/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have made corresponding changes to the documentation.

## Related Issue
Closing: 
[DEM-296](https://axem.atlassian.net/browse/DEM-296)
#215

## Description
Tool images can be uninstalled from remote hosts. 

## How Has This Been Tested?
Tested on Ubuntu 22.04.

